### PR TITLE
feat: `--android-flavor` option

### DIFF
--- a/src/__tests__/cli.ts
+++ b/src/__tests__/cli.ts
@@ -111,7 +111,7 @@ describe('cordova-res', () => {
         resourcesDirectory: 'resources',
         platforms: generatePlatformsConfig('resources'),
         projectConfig: {
-          android: { directory: 'android' },
+          android: { directory: 'android', flavor: 'main' },
           ios: { directory: 'ios' },
           windows: { directory: 'windows' },
         },
@@ -136,7 +136,7 @@ describe('cordova-res', () => {
           platforms: {
             android: generateRunOptions(Platform.ANDROID, 'resources', args),
           },
-          projectConfig: { android: { directory: 'android' } },
+          projectConfig: { android: { directory: 'android', flavor: 'main' } },
         });
       });
 
@@ -155,6 +155,18 @@ describe('cordova-res', () => {
           ...DEFAULT_OPTIONS,
           platforms,
           resourcesDirectory,
+        });
+      });
+
+      it('should accept --android-flavor flag', () => {
+        const args = ['android', '--android-flavor', 'demo'];
+        const result = parseOptions(args);
+        expect(result).toEqual({
+          ...DEFAULT_OPTIONS,
+          platforms: {
+            android: generateRunOptions(Platform.ANDROID, 'resources', args),
+          },
+          projectConfig: { android: { directory: 'android', flavor: 'demo' } },
         });
       });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,6 +35,8 @@ export const DEFAULT_RESOURCES_DIRECTORY = 'resources';
 export const DEFAULT_FIT = 'cover';
 export const DEFAULT_POSITION = 'center';
 
+export const ANDROID_DEFAULT_FLAVOR = 'main';
+
 export function getDirectory(): string {
   return process.cwd();
 }
@@ -171,8 +173,13 @@ export function generateNativeProjectConfig(
   args: readonly string[],
 ): NativeProjectConfig {
   const directory = getOptionValue(args, `--${platform}-project`, platform);
+  const flavor = getOptionValue(
+    args,
+    `--${platform}-flavor`,
+    platform === Platform.ANDROID ? ANDROID_DEFAULT_FLAVOR : undefined,
+  );
 
-  return { directory };
+  return { directory, flavor };
 }
 
 export function parseCopyOption(args: readonly string[]): boolean {

--- a/src/native.ts
+++ b/src/native.ts
@@ -45,6 +45,7 @@ import {
 
 export interface NativeProjectConfig {
   readonly directory: string;
+  readonly flavor?: string;
 }
 
 export const enum NativeResourceType {
@@ -75,7 +76,7 @@ const IOS_APP_ICON_SET_PATH = `App/App/Assets.xcassets/${IOS_APP_ICON_SET_NAME}.
 const IOS_SPLASH_IMAGE_SET_NAME = 'Splash';
 const IOS_SPLASH_IMAGE_SET_PATH = `App/App/Assets.xcassets/${IOS_SPLASH_IMAGE_SET_NAME}.imageset`;
 
-const ANDROID_RES_PATH = 'app/src/main/res';
+const ANDROID_RES_PATH = 'app/src/{FLAVOR}/res';
 
 const IOS_ICONS: readonly NativeResource[] = [
   {
@@ -405,10 +406,14 @@ export async function copyToNativeProject(
     }
   } else if (platform === Platform.ANDROID) {
     const androidProjectDirectory = nativeProject.directory || 'android';
+    const resPath = ANDROID_RES_PATH.replace(
+      '{FLAVOR}',
+      nativeProject.flavor || 'main',
+    );
     if (shouldCopyIcons) {
       count += await copyImages(
         path.join(resourcesDirectory, SOURCE_ANDROID_ICON),
-        path.join(androidProjectDirectory, ANDROID_RES_PATH),
+        path.join(androidProjectDirectory, resPath),
         ANDROID_ICONS,
         errstream,
       );
@@ -416,7 +421,7 @@ export async function copyToNativeProject(
     if (shouldCopySplash) {
       count += await copyImages(
         path.join(resourcesDirectory, SOURCE_ANDROID_SPLASH),
-        path.join(androidProjectDirectory, ANDROID_RES_PATH),
+        path.join(androidProjectDirectory, resPath),
         ANDROID_SPLASHES,
         errstream,
       );

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -5,12 +5,12 @@ export function getOptionValue(
 export function getOptionValue(
   args: readonly string[],
   arg: string,
-  defaultValue: string,
+  defaultValue: string | undefined,
 ): string;
 export function getOptionValue(
   args: readonly string[],
   arg: string,
-  defaultValue?: string,
+  defaultValue?: string | undefined,
 ): string | undefined {
   const i = args.indexOf(arg);
 


### PR DESCRIPTION
This PR introduces the `--android-flavor` option which allows to specify the subdirectory to which Android resources will be copied (i.e. substitute `main` for another flavor such as `demo` in the default path `app/src/main/res`).