### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Note: previous versions of this tool supported Cordova but Cordova support has b
 ## Install
 
 ```bash
-$ npm install @capacitor/assets@next
+$ npm install @capacitor/assets
 ```
 
 Then add this script to your `package.json`:


### PR DESCRIPTION
`npm install @capacitor/assets@next` installs an old version `1.0.0-next.5`