### PR TITLE
Fix help message for --assetPath

### DIFF
--- a/src/tasks/generate.ts
+++ b/src/tasks/generate.ts
@@ -14,7 +14,7 @@ export async function run(ctx: Context): Promise<OutputAsset[]> {
   try {
     if (!(await ctx.project.assetDirExists())) {
       error(
-        `Asset directory not found at ${ctx.project.projectRoot}. Use --asset-path to specify a specific directory containing assets`
+        `Asset directory not found at ${ctx.project.projectRoot}. Use --assetPath to specify a specific directory containing assets`
       );
       return [];
     }


### PR DESCRIPTION
As per 
https://github.com/ionic-team/capacitor-assets/blob/main/src/index.ts#L67 
the suggested command should be `--assetPath` and not `--asset-path`