### PR TITLE
Platform specific generation

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -44,6 +44,7 @@ export const enum AssetKind {
 }
 
 export const enum Platform {
+  Any = 'any',
   Ios = 'ios',
   Android = 'android',
   Pwa = 'pwa',

--- a/src/input-asset.ts
+++ b/src/input-asset.ts
@@ -1,6 +1,6 @@
 import { basename, extname, join } from 'path';
 import sharp from 'sharp';
-import { AssetKind, Format } from './definitions';
+import { AssetKind, Format, Platform } from './definitions';
 import { OutputAsset } from './output-asset';
 import { Project } from './project';
 import { AssetGenerator } from './asset-generator';
@@ -16,7 +16,7 @@ export class InputAsset {
 
   private _sharp: sharp.Sharp | null = null;
 
-  constructor(public path: string, public kind: AssetKind) {
+  constructor(public path: string, public kind: AssetKind, public platform: Platform) {
     this.filename = basename(path);
   }
 

--- a/src/platforms/android/index.ts
+++ b/src/platforms/android/index.ts
@@ -9,7 +9,7 @@ import {
   AndroidOutputAssetTemplateAdaptiveIcon,
   AndroidOutputAssetTemplateSplash,
   AssetKind,
-  OutputAssetTemplate,
+  Platform,
 } from '../../definitions';
 import { BadPipelineError, BadProjectError } from '../../error';
 import { OutputAsset } from '../../output-asset';
@@ -28,6 +28,10 @@ export class AndroidAssetGenerator extends AssetGenerator {
 
     if (!androidDir) {
       throw new BadProjectError('No android project found');
+    }
+
+    if (asset.platform !== Platform.Any && asset.platform !== Platform.Android) {
+      return [];
     }
 
     switch (asset.kind) {

--- a/src/platforms/ios/index.ts
+++ b/src/platforms/ios/index.ts
@@ -2,7 +2,7 @@ import { join } from 'path';
 import { readFile, writeFile } from '@ionic/utils-fs';
 
 import { InputAsset } from '../../input-asset';
-import { AssetKind, IosOutputAssetTemplate } from '../../definitions';
+import { AssetKind, IosOutputAssetTemplate, Platform } from '../../definitions';
 import { BadPipelineError, BadProjectError } from '../../error';
 import { OutputAsset } from '../../output-asset';
 import { Project } from '../../project';
@@ -33,6 +33,10 @@ export class IosAssetGenerator extends AssetGenerator {
 
     if (!iosDir) {
       throw new BadProjectError('No ios project found');
+    }
+
+    if (asset.platform !== Platform.Any && asset.platform !== Platform.Ios) {
+      return [];
     }
 
     switch (asset.kind) {

--- a/src/platforms/pwa/index.ts
+++ b/src/platforms/pwa/index.ts
@@ -87,6 +87,10 @@ export class PwaAssetGenerator extends AssetGenerator {
       throw new BadProjectError('No web app (PWA) found');
     }
 
+    if (asset.platform !== Platform.Any) {
+      return [];
+    }
+
     switch (asset.kind) {
       case AssetKind.Logo:
       case AssetKind.LogoDark:

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,5 +1,5 @@
 import { Framework, MobileProject, MobileProjectConfig } from '@trapezedev/project';
-import { AssetKind, Assets } from './definitions';
+import { AssetKind, Assets, Platform } from './definitions';
 import { join } from 'path';
 import { pathExists } from '@ionic/utils-fs';
 import { InputAsset } from './input-asset';
@@ -45,40 +45,44 @@ export class Project extends MobileProject {
   async loadInputAssets(): Promise<Assets> {
     this.assets = {
       logo: await this.loadLogoInputAsset(),
-      logoDark: await this.loadInputAsset('logo-dark', AssetKind.LogoDark),
-      icon: await this.loadInputAsset('icon-only', AssetKind.Icon),
-      iconForeground: await this.loadInputAsset('icon-foreground', AssetKind.IconForeground),
-      iconBackground: await this.loadInputAsset('icon-background', AssetKind.IconBackground),
-      splash: await this.loadInputAsset('splash', AssetKind.Splash),
-      splashDark: await this.loadInputAsset('splash-dark', AssetKind.SplashDark),
+      logoDark: await this.loadInputAsset('logo-dark', AssetKind.LogoDark, Platform.Any),
+      icon: await this.loadInputAsset('icon-only', AssetKind.Icon, Platform.Any),
+      iconForeground: await this.loadInputAsset('icon-foreground', AssetKind.IconForeground, Platform.Any),
+      iconBackground: await this.loadInputAsset('icon-background', AssetKind.IconBackground, Platform.Any),
+      splash: await this.loadInputAsset('splash', AssetKind.Splash, Platform.Any),
+      splashDark: await this.loadInputAsset('splash-dark', AssetKind.SplashDark, Platform.Any),
 
-      iosIcon: await this.loadInputAsset('ios/icon', AssetKind.Icon),
-      iosSplash: await this.loadInputAsset('ios/splash', AssetKind.Splash),
-      iosSplashDark: await this.loadInputAsset('ios/splash-dark', AssetKind.SplashDark),
-      iosNotificationIcon: await this.loadInputAsset('ios/notification-icon', AssetKind.NotificationIcon),
-      iosSettingsIcon: await this.loadInputAsset('ios/settings-icon', AssetKind.SettingsIcon),
-      iosSpotlightIcon: await this.loadInputAsset('ios/spotlight-icon', AssetKind.SpotlightIcon),
+      iosIcon: await this.loadInputAsset('ios/icon', AssetKind.Icon, Platform.Ios),
+      iosSplash: await this.loadInputAsset('ios/splash', AssetKind.Splash, Platform.Ios),
+      iosSplashDark: await this.loadInputAsset('ios/splash-dark', AssetKind.SplashDark, Platform.Ios),
+      iosNotificationIcon: await this.loadInputAsset('ios/notification-icon', AssetKind.NotificationIcon, Platform.Ios),
+      iosSettingsIcon: await this.loadInputAsset('ios/settings-icon', AssetKind.SettingsIcon, Platform.Ios),
+      iosSpotlightIcon: await this.loadInputAsset('ios/spotlight-icon', AssetKind.SpotlightIcon, Platform.Ios),
 
-      androidIcon: await this.loadInputAsset('android/icon', AssetKind.Icon),
-      androidIconForeground: await this.loadInputAsset('android/icon-foreground', AssetKind.Icon),
-      androidIconBackground: await this.loadInputAsset('android/icon-background', AssetKind.Icon),
+      androidIcon: await this.loadInputAsset('android/icon', AssetKind.Icon, Platform.Android),
+      androidIconForeground: await this.loadInputAsset('android/icon-foreground', AssetKind.Icon, Platform.Android),
+      androidIconBackground: await this.loadInputAsset('android/icon-background', AssetKind.Icon, Platform.Android),
 
-      androidSplash: await this.loadInputAsset('android/splash', AssetKind.Splash),
-      androidSplashDark: await this.loadInputAsset('android/splash-dark', AssetKind.SplashDark),
-      androidNotificationIcon: await this.loadInputAsset('android/notification', AssetKind.NotificationIcon),
+      androidSplash: await this.loadInputAsset('android/splash', AssetKind.Splash, Platform.Android),
+      androidSplashDark: await this.loadInputAsset('android/splash-dark', AssetKind.SplashDark, Platform.Android),
+      androidNotificationIcon: await this.loadInputAsset(
+        'android/notification',
+        AssetKind.NotificationIcon,
+        Platform.Android
+      ),
     };
     return this.assets;
   }
 
   private async loadLogoInputAsset() {
-    let logo = await this.loadInputAsset('logo', AssetKind.Logo);
+    let logo = await this.loadInputAsset('logo', AssetKind.Logo, Platform.Any);
     if (!logo) {
-      logo = await this.loadInputAsset('icon', AssetKind.Logo);
+      logo = await this.loadInputAsset('icon', AssetKind.Logo, Platform.Any);
     }
     return logo;
   }
 
-  private async loadInputAsset(path: string, kind: AssetKind) {
+  private async loadInputAsset(path: string, kind: AssetKind, platform: Platform) {
     let imagePath: string | null = null;
 
     const extensions = ['.png', '.webp', '.jpg', '.jpeg', '.svg'];
@@ -95,7 +99,7 @@ export class Project extends MobileProject {
       return null;
     }
 
-    const asset = new InputAsset(imagePath, kind);
+    const asset = new InputAsset(imagePath, kind, platform);
 
     try {
       await asset.load();

--- a/test/task.generate.test.ts
+++ b/test/task.generate.test.ts
@@ -4,6 +4,7 @@ import tempy from 'tempy';
 
 import { Context, loadContext } from '../src/ctx';
 import { Format } from '../src/definitions';
+import { OutputAsset } from '../src/output-asset';
 
 describe('Task: Generate test', () => {
   let ctx: Context;
@@ -22,15 +23,30 @@ describe('Task: Generate test', () => {
     await rm(fixtureDir, { force: true, recursive: true });
   });
 
+  function log(target: string, generated: OutputAsset[]) {
+    console.log('-'.repeat(10), target.toUpperCase(), '-'.repeat(10));
+    console.log(
+      generated
+        .filter((g) => {
+          return Object.values(g.destFilenames)[0].includes(target);
+        })
+        .map((g) => Object.values(g.destFilenames).map((f) => f.replace(fixtureDir, '')))
+        .flat()
+        .sort()
+    );
+  }
+
   it('Should generate all project assets', async () => {
     const { run } = await import('../src/tasks/generate');
 
     const generated = await run(ctx);
 
-    // console.log(generated.map(g => Object.values(g.destFilenames)).flat());
+    // log('ios', generated);
+    // log('android', generated);
+    // log('public', generated);
 
     // TODO: Make this more specific instead of "it generated a lot of assets"
-    expect(generated.length).toBeGreaterThan(100);
+    expect(generated.length).toBeGreaterThan(97);
   });
 
   it('Should support custom pwa manifest dir', async () => {


### PR DESCRIPTION
Only generate assets for that specific target platform. This also results in lesser generation and faster completion.

Fixes a bug in #118 where I had iOS icons overridden by a custom android icon.

Idk if my "Platform.Any" change is OK for you, but seemed the only way by still reusing existing stuff.

<details>
<summary>Diff</summary>

```diff
--- test/previous.log	2022-11-09 11:28:30
+++ test/now.log	2022-11-09 11:32:36
@@ -4,11 +4,11 @@
 
  PASS  test/platforms/pwa.asset.test.ts
  PASS  test/platforms/ios.asset.test.ts
- PASS  test/asset.svg.test.ts
  PASS  test/asset.test.ts
- PASS  test/platforms/android.asset.test.ts (5.36 s)
+ PASS  test/asset.svg.test.ts
+ PASS  test/platforms/android.asset.test.ts
  PASS  test/platforms/pwa.manifest.test.ts
- PASS  test/task.generate.test.ts (6.088 s)
+ FAIL  test/task.generate.test.ts (5.066 s)
   ● Console
 
     console.log
@@ -32,22 +32,16 @@
         '/ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-40x40@3x.png',
         '/ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-512@2x.png',
         '/ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-512@2x.png',
-        '/ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-512@2x.png',
         '/ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-60x60@2x.png',
         '/ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-60x60@2x.png',
-        '/ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-60x60@2x.png',
         '/ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-60x60@3x.png',
         '/ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-60x60@3x.png',
-        '/ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-60x60@3x.png',
         '/ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-76x76@1x.png',
         '/ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-76x76@1x.png',
-        '/ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-76x76@1x.png',
         '/ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-76x76@2x.png',
         '/ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-76x76@2x.png',
-        '/ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-76x76@2x.png',
         '/ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-83.5x83.5@2x.png',
         '/ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-83.5x83.5@2x.png',
-        '/ios/App/App/Assets.xcassets/AppIcon.appiconset/AppIcon-83.5x83.5@2x.png',
         '/ios/App/App/Assets.xcassets/Splash.imageset/Default@1x~universal~anyany-dark.png',
         '/ios/App/App/Assets.xcassets/Splash.imageset/Default@1x~universal~anyany.png',
         '/ios/App/App/Assets.xcassets/Splash.imageset/Default@2x~universal~anyany-dark.png',
@@ -115,51 +109,39 @@
         '/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml',
         '/android/app/src/main/res/mipmap-hdpi/ic_launcher.png',
         '/android/app/src/main/res/mipmap-hdpi/ic_launcher.png',
-        '/android/app/src/main/res/mipmap-hdpi/ic_launcher.png',
         '/android/app/src/main/res/mipmap-hdpi/ic_launcher_background.png',
         '/android/app/src/main/res/mipmap-hdpi/ic_launcher_foreground.png',
         '/android/app/src/main/res/mipmap-hdpi/ic_launcher_round.png',
         '/android/app/src/main/res/mipmap-hdpi/ic_launcher_round.png',
-        '/android/app/src/main/res/mipmap-hdpi/ic_launcher_round.png',
         '/android/app/src/main/res/mipmap-ldpi/ic_launcher.png',
         '/android/app/src/main/res/mipmap-ldpi/ic_launcher.png',
-        '/android/app/src/main/res/mipmap-ldpi/ic_launcher.png',
         '/android/app/src/main/res/mipmap-ldpi/ic_launcher_background.png',
         '/android/app/src/main/res/mipmap-ldpi/ic_launcher_foreground.png',
         '/android/app/src/main/res/mipmap-ldpi/ic_launcher_round.png',
         '/android/app/src/main/res/mipmap-ldpi/ic_launcher_round.png',
-        '/android/app/src/main/res/mipmap-ldpi/ic_launcher_round.png',
         '/android/app/src/main/res/mipmap-mdpi/ic_launcher.png',
         '/android/app/src/main/res/mipmap-mdpi/ic_launcher.png',
-        '/android/app/src/main/res/mipmap-mdpi/ic_launcher.png',
         '/android/app/src/main/res/mipmap-mdpi/ic_launcher_background.png',
         '/android/app/src/main/res/mipmap-mdpi/ic_launcher_foreground.png',
         '/android/app/src/main/res/mipmap-mdpi/ic_launcher_round.png',
         '/android/app/src/main/res/mipmap-mdpi/ic_launcher_round.png',
-        '/android/app/src/main/res/mipmap-mdpi/ic_launcher_round.png',
         '/android/app/src/main/res/mipmap-xhdpi/ic_launcher.png',
         '/android/app/src/main/res/mipmap-xhdpi/ic_launcher.png',
-        '/android/app/src/main/res/mipmap-xhdpi/ic_launcher.png',
         '/android/app/src/main/res/mipmap-xhdpi/ic_launcher_background.png',
         '/android/app/src/main/res/mipmap-xhdpi/ic_launcher_foreground.png',
         '/android/app/src/main/res/mipmap-xhdpi/ic_launcher_round.png',
         '/android/app/src/main/res/mipmap-xhdpi/ic_launcher_round.png',
-        '/android/app/src/main/res/mipmap-xhdpi/ic_launcher_round.png',
         '/android/app/src/main/res/mipmap-xxhdpi/ic_launcher.png',
         '/android/app/src/main/res/mipmap-xxhdpi/ic_launcher.png',
-        '/android/app/src/main/res/mipmap-xxhdpi/ic_launcher.png',
         '/android/app/src/main/res/mipmap-xxhdpi/ic_launcher_background.png',
         '/android/app/src/main/res/mipmap-xxhdpi/ic_launcher_foreground.png',
         '/android/app/src/main/res/mipmap-xxhdpi/ic_launcher_round.png',
         '/android/app/src/main/res/mipmap-xxhdpi/ic_launcher_round.png',
-        '/android/app/src/main/res/mipmap-xxhdpi/ic_launcher_round.png',
         '/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png',
         '/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png',
-        '/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png',
         '/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher_background.png',
         '/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher_foreground.png',
         '/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.png',
-        '/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.png',
         '/android/app/src/main/res/mipmap-xxxhdpi/ic_launcher_round.png'
       ]
 
@@ -173,33 +155,53 @@
     console.log
       [
         '/public/assets/icons/icon-128.webp',
-        '/public/assets/icons/icon-128.webp',
-        '/public/assets/icons/icon-128.webp',
         '/public/assets/icons/icon-192.webp',
         '/public/assets/icons/icon-192.webp',
-        '/public/assets/icons/icon-192.webp',
-        '/public/assets/icons/icon-192.webp',
-        '/public/assets/icons/icon-192.webp',
-        '/public/assets/icons/icon-192.webp',
         '/public/assets/icons/icon-256.webp',
-        '/public/assets/icons/icon-256.webp',
-        '/public/assets/icons/icon-256.webp',
         '/public/assets/icons/icon-512.webp',
-        '/public/assets/icons/icon-512.webp',
-        '/public/assets/icons/icon-512.webp',
         '/public/assets/icons/icon-72.webp',
-        '/public/assets/icons/icon-72.webp',
-        '/public/assets/icons/icon-72.webp',
-        '/public/assets/icons/icon-96.webp',
-        '/public/assets/icons/icon-96.webp',
         '/public/assets/icons/icon-96.webp'
       ]
 
       at log (test/task.generate.test.ts:28:13)
 
+  ● Task: Generate test › Should generate all project assets
 
-Test Suites: 7 passed, 7 total
-Tests:       1 skipped, 20 passed, 21 total
+    expect(received).toBeGreaterThan(expected)
+
+    Expected: > 97
+    Received:   97
+
+      47 |
+      48 |     // TODO: Make this more specific instead of "it generated a lot of assets"
+    > 49 |     expect(generated.length).toBeGreaterThan(97);
+         |                              ^
+      50 |   });
+      51 |
+      52 |   it('Should support custom pwa manifest dir', async () => {
+
+      at Object.<anonymous> (test/task.generate.test.ts:49:30)
+
+  ● Task: Generate test › Should support custom pwa manifest dir
+
+    expect(received).toBeGreaterThan(expected)
+
+    Expected: > 100
+    Received:   97
+
+      63 |
+      64 |     // TODO: Make this more specific instead of "it generated a lot of assets"
+    > 65 |     expect(generated.length).toBeGreaterThan(100);
+         |                              ^
+      66 |   });
+      67 | });
+      68 |
+
+      at Object.<anonymous> (test/task.generate.test.ts:65:30)
+
+Test Suites: 1 failed, 6 passed, 7 total
+Tests:       2 failed, 1 skipped, 18 passed, 21 total
 Snapshots:   0 total
-Time:        6.298 s
-Ran all test suites.
\ No newline at end of file
+Time:        5.283 s, estimated 6 s
+Ran all test suites.
+ ELIFECYCLE  Test failed. See above for more details.
\ No newline at end of file
```

</details>