### PR TITLE
Allow setting a padding on android icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Where the provided flags are:
 - `--logoSplashScale` - the scale multiplier to apply to the logo when generating splash screens from a single logo file (default: `0.2`)
 - `--ios` - explicitly run iOS asset generation. Using a platform flag makes the platform list exclusive.
 - `--android` - explicitly run Android asset generation. Using a platform flag makes the platform list exclusive.
-- `--android-padding` - set a icon padding that behaves like scaling. (default: `8`)
+- `--android-resize` - resize the non-legacy android icons based on a percentage.
 - `--pwa` - explicitly run Android asset generation. Using a platform flag makes the platform list exclusive.
 
 ### Usage - Custom Mode

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Where the provided flags are:
 - `--logoSplashScale` - the scale multiplier to apply to the logo when generating splash screens from a single logo file (default: `0.2`)
 - `--ios` - explicitly run iOS asset generation. Using a platform flag makes the platform list exclusive.
 - `--android` - explicitly run Android asset generation. Using a platform flag makes the platform list exclusive.
+- `--android-padding` - set a icon padding that behaves like scaling. (default: `8`)
 - `--pwa` - explicitly run Android asset generation. Using a platform flag makes the platform list exclusive.
 
 ### Usage - Custom Mode

--- a/src/asset-generator.ts
+++ b/src/asset-generator.ts
@@ -27,6 +27,6 @@ export interface AssetGeneratorOptions {
   logoSplashTargetWidth?: number;
   // Android product flavor name where generated assets will be created. Default: main
   androidFlavor?: string;
-  // Android icon padding which behaves like scaling. Default: 8
-  androidPadding?: number;
+  // Android resize will resize the non-legacy android icons based on a percentage
+  androidResize?: number;
 }

--- a/src/asset-generator.ts
+++ b/src/asset-generator.ts
@@ -27,4 +27,6 @@ export interface AssetGeneratorOptions {
   logoSplashTargetWidth?: number;
   // Android product flavor name where generated assets will be created. Default: main
   androidFlavor?: string;
+  // Android icon padding which behaves like scaling. Default: 8
+  androidPadding?: number;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,11 @@ export function runProgram(ctx: Context) {
       '--android-flavor <name>',
       'Android product flavor name where generated assets will be created. Defaults to "main".'
     )
-    .option('--android-padding <floatVal>', 'Android icon padding that behaves like scaling.')
+    .option(
+      '--android-resize <floatVal>',
+      'Android resize will resize the non-legacy android icons based on a percentage.',
+      Number
+    )
     .option('--ios-project <dir>', 'Path to iOS project (defaults to "ios/App")')
     .option('--android-project <dir>', 'Path to Android project (defaults to "android")')
     /*

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ export function runProgram(ctx: Context) {
       '--android-flavor <name>',
       'Android product flavor name where generated assets will be created. Defaults to "main".'
     )
+    .option('--android-padding <floatVal>', 'Android icon padding that behaves like scaling.')
     .option('--ios-project <dir>', 'Path to iOS project (defaults to "ios/App")')
     .option('--android-project <dir>', 'Path to Android project (defaults to "android")')
     /*

--- a/src/platforms/android/index.ts
+++ b/src/platforms/android/index.ts
@@ -24,7 +24,7 @@ export class AndroidAssetGenerator extends AssetGenerator {
   constructor(options: AssetGeneratorOptions = {}) {
     super(options);
 
-    this.resizeValue = options.androidResize ?? 8;
+    this.resizeValue = options.androidResize ?? 100;
   }
 
   async generate(asset: InputAsset, project: Project): Promise<OutputAsset[]> {

--- a/test/platforms/android.asset.test.ts
+++ b/test/platforms/android.asset.test.ts
@@ -29,8 +29,11 @@ describe('Android asset test', () => {
   });
 
   afterAll(async () => {
-    console.log('Using text/fixtures/app Wrote to', join(fixtureDir, 'android', 'app', 'src', 'main', 'res'));
     /*
+    console.log(
+      'Using text/fixtures/app Wrote to',
+      join(fixtureDir, 'android', 'app', 'src', 'main', 'res'),
+    );
     const files = await readdirp(
       join(fixtureDir, 'android', 'app', 'src', 'main', 'res'),
     );
@@ -46,7 +49,7 @@ describe('Android asset test', () => {
     );
     // console.log(await readFile(join(fixtureDir, 'android', 'app', 'src', 'main', 'AndroidManifest.xml'), { encoding: 'utf-8' }));
     */
-    // await rm(fixtureDir, { force: true, recursive: true });
+    await rm(fixtureDir, { force: true, recursive: true });
   });
 
   async function verifySizes(generatedAssets: OutputAsset<AndroidOutputAssetTemplate>[]) {

--- a/test/platforms/android.asset.test.ts
+++ b/test/platforms/android.asset.test.ts
@@ -29,11 +29,8 @@ describe('Android asset test', () => {
   });
 
   afterAll(async () => {
+    console.log('Using text/fixtures/app Wrote to', join(fixtureDir, 'android', 'app', 'src', 'main', 'res'));
     /*
-    console.log(
-      'Using text/fixtures/app Wrote to',
-      join(fixtureDir, 'android', 'app', 'src', 'main', 'res'),
-    );
     const files = await readdirp(
       join(fixtureDir, 'android', 'app', 'src', 'main', 'res'),
     );
@@ -49,7 +46,7 @@ describe('Android asset test', () => {
     );
     // console.log(await readFile(join(fixtureDir, 'android', 'app', 'src', 'main', 'AndroidManifest.xml'), { encoding: 'utf-8' }));
     */
-    await rm(fixtureDir, { force: true, recursive: true });
+    // await rm(fixtureDir, { force: true, recursive: true });
   });
 
   async function verifySizes(generatedAssets: OutputAsset<AndroidOutputAssetTemplate>[]) {


### PR DESCRIPTION
Adds an option `--android-resize`, that allows scaling the source image for modern icons (API>24).

Closes #118 