### PR TITLE
fix android splash dir name 'drawable'

### DIFF
--- a/src/platforms/android/index.ts
+++ b/src/platforms/android/index.ts
@@ -511,7 +511,7 @@ export class AndroidAssetGenerator extends AssetGenerator {
     template: AndroidOutputAssetTemplateSplash,
     pipe: Sharp
   ): Promise<[string, OutputInfo]> {
-    const drawableDir = `drawable-${template.density}`;
+    const drawableDir = template.density ? `drawable-${template.density}` : 'drawable';
 
     const resPath = this.getResPath(project);
     const parentDir = join(resPath, drawableDir);


### PR DESCRIPTION
when setting android assets with `npx capacitor-assets generate`, I find a dir `android/app/src/main/res/drawable-`.

Android Studio (2021.3.1 MacOS) throws an error complaining about this dirname. 

Changing it to `android/app/src/main/res/drawable` fixed it for me, although I am not sure if this is how it is intended by the Android APIs.

![Screenshot 2022-11-18 at 11 53 21](https://user-images.githubusercontent.com/15275319/202689088-e6b284ff-f5d6-4261-8641-dfdee579e76b.png)

![Screenshot 2022-11-18 at 11 54 08](https://user-images.githubusercontent.com/15275319/202689185-963ffcf1-4bb4-4227-b7ff-a168f8a45ab7.png)

A quick glance at the code lets me guess it happens at https://github.com/ionic-team/capacitor-assets/blob/100427d59c6f2f041c96b1163241b084b6629e7e/src/platforms/android/index.ts#L514

this fixes this issue for me, but it might be preferable to change the template's output.