### PR TITLE
fix: pwa icon generation and angular vue path

### DIFF
--- a/src/platforms/android/index.ts
+++ b/src/platforms/android/index.ts
@@ -271,9 +271,6 @@ export class AndroidAssetGenerator extends AssetGenerator {
     asset: InputAsset,
     template: AndroidOutputAssetTemplate,
   ): Promise<[string, OutputInfo]> {
-    //const radius = 4;
-    //const svg = `<svg width="${template.width}" height="${template.height}"><rect x="0" y="0" width="${template.width}" height="${template.height}" rx="${radius}" fill="#ffffff"/></svg>`;
-
     const resPath = this.getResPath(project);
     const parentDir = join(resPath, `mipmap-${template.density}`);
     if (!(await pathExists(parentDir))) {

--- a/src/platforms/android/index.ts
+++ b/src/platforms/android/index.ts
@@ -233,7 +233,7 @@ export class AndroidAssetGenerator extends AssetGenerator {
 
     const collected = await Promise.all(
       icons.map(async (icon) => {
-        const [dest, outputInfo] = await this.generateLegacyLauncherIcon(project, asset, icon, pipe);
+        const [dest, outputInfo] = await this.generateLegacyLauncherIcon(project, asset, icon);
 
         return new OutputAsset(
           icon,
@@ -248,7 +248,7 @@ export class AndroidAssetGenerator extends AssetGenerator {
     collected.push(
       ...(await Promise.all(
         icons.map(async (icon) => {
-          const [dest, outputInfo] = await this.generateRoundLauncherIcon(project, asset, icon, pipe);
+          const [dest, outputInfo] = await this.generateRoundLauncherIcon(project, asset, icon);
 
           return new OutputAsset(
             icon,
@@ -270,10 +270,9 @@ export class AndroidAssetGenerator extends AssetGenerator {
     project: Project,
     asset: InputAsset,
     template: AndroidOutputAssetTemplate,
-    pipe: Sharp,
   ): Promise<[string, OutputInfo]> {
-    const radius = 4;
-    const svg = `<svg width="${template.width}" height="${template.height}"><rect x="0" y="0" width="${template.width}" height="${template.height}" rx="${radius}" fill="#ffffff"/></svg>`;
+    //const radius = 4;
+    //const svg = `<svg width="${template.width}" height="${template.height}"><rect x="0" y="0" width="${template.width}" height="${template.height}" rx="${radius}" fill="#ffffff"/></svg>`;
 
     const resPath = this.getResPath(project);
     const parentDir = join(resPath, `mipmap-${template.density}`);
@@ -308,7 +307,6 @@ export class AndroidAssetGenerator extends AssetGenerator {
     project: Project,
     asset: InputAsset,
     template: AndroidOutputAssetTemplate,
-    pipe: Sharp,
   ): Promise<[string, OutputInfo]> {
     const svg = `<svg width="${template.width}" height="${template.height}"><circle cx="${template.width / 2}" cy="${
       template.height / 2

--- a/src/platforms/pwa/index.ts
+++ b/src/platforms/pwa/index.ts
@@ -452,9 +452,6 @@ export class PwaAssetGenerator extends AssetGenerator {
     }
     const dest = join(destDir, name);
 
-    // console.log(width, height);
-    //const targetLogoWidthPercent = this.options.logoSplashScale ?? 0.2;
-    //const targetWidth = Math.floor(width * targetLogoWidthPercent);
     const outputInfo = await pipe.resize(width, height).png().toFile(dest);
 
     const template: PwaOutputAssetTemplate = {


### PR DESCRIPTION
FIxes WN-1459
When `npx @capacitor/assets generate --pwa` is run with an angular or vue project it looks in `src/assets/assets`  folder but the default path for angular and vue assets is just `src/assets`.

This also replaces any icons in the `manifest.webmanifest` file (it would previously only change an icon if the filename existed already in the file.

Note: also reduced the linting errors

This should also fix #568 which is a side effect of not choosing the path correctly in an Angular or Vue project.
Also fixes #520 which is caused by it checking for icons by their filename rather than their size.