### PR TITLE
Fix for the issue 622 dark mode icons for android

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -30,6 +30,7 @@ export const enum AssetKind {
   Logo = 'logo',
   LogoDark = 'logo-dark',
   AdaptiveIcon = 'adaptive-icon',
+  AdaptiveIconDark = 'adaptive-icon-dark',
   Icon = 'icon',
   IconForeground = 'icon-foreground',
   IconBackground = 'icon-background',

--- a/src/platforms/android/assets.ts
+++ b/src/platforms/android/assets.ts
@@ -116,6 +116,61 @@ export const ANDROID_XXXHDPI_ADAPTIVE_ICON: AndroidOutputAssetTemplateAdaptiveIc
   density: AndroidDensity.Xxxhdpi,
 };
 
+// Dark/night mode adaptive icons
+export const ANDROID_LDPI_ADAPTIVE_ICON_DARK: AndroidOutputAssetTemplateAdaptiveIcon = {
+  platform: Platform.Android,
+  kind: AssetKind.AdaptiveIconDark,
+  format: Format.Png,
+  width: 81,
+  height: 81,
+  density: AndroidDensity.LdpiNight,
+};
+
+export const ANDROID_MDPI_ADAPTIVE_ICON_DARK: AndroidOutputAssetTemplateAdaptiveIcon = {
+  platform: Platform.Android,
+  kind: AssetKind.AdaptiveIconDark,
+  format: Format.Png,
+  width: 108,
+  height: 108,
+  density: AndroidDensity.MdpiNight,
+};
+
+export const ANDROID_HDPI_ADAPTIVE_ICON_DARK: AndroidOutputAssetTemplateAdaptiveIcon = {
+  platform: Platform.Android,
+  kind: AssetKind.AdaptiveIconDark,
+  format: Format.Png,
+  width: 162,
+  height: 162,
+  density: AndroidDensity.HdpiNight,
+};
+
+export const ANDROID_XHDPI_ADAPTIVE_ICON_DARK: AndroidOutputAssetTemplateAdaptiveIcon = {
+  platform: Platform.Android,
+  kind: AssetKind.AdaptiveIconDark,
+  format: Format.Png,
+  width: 216,
+  height: 216,
+  density: AndroidDensity.XhdpiNight,
+};
+
+export const ANDROID_XXHDPI_ADAPTIVE_ICON_DARK: AndroidOutputAssetTemplateAdaptiveIcon = {
+  platform: Platform.Android,
+  kind: AssetKind.AdaptiveIconDark,
+  format: Format.Png,
+  width: 324,
+  height: 324,
+  density: AndroidDensity.XxhdpiNight,
+};
+
+export const ANDROID_XXXHDPI_ADAPTIVE_ICON_DARK: AndroidOutputAssetTemplateAdaptiveIcon = {
+  platform: Platform.Android,
+  kind: AssetKind.AdaptiveIconDark,
+  format: Format.Png,
+  width: 432,
+  height: 432,
+  density: AndroidDensity.XxxhdpiNight,
+};
+
 //
 // Splash screens
 //

--- a/test/platforms/android.asset.test.ts
+++ b/test/platforms/android.asset.test.ts
@@ -1,4 +1,4 @@
-import { copy, pathExists, readdirp, readFile, rmSync as rm, statSync } from '@ionic/utils-fs';
+import { copy, pathExists, rmSync as rm } from '@ionic/utils-fs';
 import tempy from 'tempy';
 import sharp from 'sharp';
 import { join } from 'path';
@@ -7,12 +7,10 @@ import { Context, loadContext } from '../../src/ctx';
 import {
   AndroidOutputAssetTemplate,
   AndroidOutputAssetTemplateAdaptiveIcon,
-  AssetKind,
   Assets,
 } from '../../src/definitions';
 import { OutputAsset } from '../../src/output-asset';
 import { AndroidAssetGenerator } from '../../src/platforms/android';
-import * as AndroidAssets from '../../src/platforms/android/assets';
 
 describe('Android asset test', () => {
   let ctx: Context;
@@ -187,7 +185,7 @@ describe('Android Asset Test - Logo Only', () => {
     let generatedAssets = ((await assets.logoDark?.generate(strategy, ctx.project)) ??
       []) as OutputAsset<AndroidOutputAssetTemplate>[];
 
-    expect(generatedAssets.length).toBe(13);
+    expect(generatedAssets.length).toBe(25);
     await verifySizes(generatedAssets);
   });
 


### PR DESCRIPTION
Fix for the [issue 622](https://github.com/ionic-team/capacitor-assets/issues/622) dark mode icons support for android